### PR TITLE
Make the function argument const to appease compiler warning.

### DIFF
--- a/main.c
+++ b/main.c
@@ -850,7 +850,7 @@ err0:
 }
 
 static void
-printstatus(char * prefix, char * status, char ** laststatus)
+printstatus(const char * prefix, char * status, char ** laststatus)
 {
 
 	/* Comparing old status to new status... */


### PR DESCRIPTION
The compiler was warning about it and I thought it was safe to mark the argument as `const` at this place.